### PR TITLE
adding char fields to fill in when they had previous TB

### DIFF
--- a/lib/opal-tb/tb/migrations/0042_auto_20160826_1217.py
+++ b/lib/opal-tb/tb/migrations/0042_auto_20160826_1217.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tb', '0041_auto_20160822_1054'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='tbhistory',
+            name='date_of_other_tb_contact',
+            field=models.CharField(max_length=255, null=True, verbose_name=b'Date of TB Contact', blank=True),
+        ),
+        migrations.AddField(
+            model_name='tbhistory',
+            name='date_of_previous_tb_infection',
+            field=models.CharField(max_length=255, null=True, verbose_name=b'Date of Previous TB Infection', blank=True),
+        ),
+    ]

--- a/lib/opal-tb/tb/models.py
+++ b/lib/opal-tb/tb/models.py
@@ -306,7 +306,9 @@ class TBHistory(models.PatientSubrecord):
     _icon = 'fa fa-wpforms'
     _title = "History of TB"
     personal_history_of_tb = fields.TextField(blank=True, null=True, verbose_name="Personal History of TB")
+    date_of_previous_tb_infection = fields.CharField(max_length=255, blank=True, null=True, verbose_name="Date of Previous TB")
     other_tb_contact = fields.TextField(blank=True, null=True, verbose_name="Other TB Contact")
+    date_of_other_tb_contact = fields.CharField(max_length=255, blank=True, null=True, verbose_name="Date of TB Contact")
 
 class BCG(models.PatientSubrecord):
     _icon = 'fa fa-asterisk'

--- a/lib/opal-tb/tb/templates/forms/tb_history_form.html
+++ b/lib/opal-tb/tb/templates/forms/tb_history_form.html
@@ -1,3 +1,5 @@
 {% load forms %}
 {% textarea  field="TBHistory.personal_history_of_tb"  %}
+{% input field="TBHistory.date_of_previous_tb_infection" show="editing.tb_history.personal_history_of_tb[0].length" %}
 {% textarea  field="TBHistory.other_tb_contact"  %}
+{% input field="TBHistory.date_of_other_tb_contact" show="editing.tb_history.other_tb_contact[0].length" %}


### PR DESCRIPTION
so we now just add a charfield to fill in when they had previous contact/infection to match the existing mile end screens.

I think this is a fine stop gap until we can do something fancier, I think they'll want to know if its MDR and where they had it etc. This will come.
